### PR TITLE
remove unicode characters from manifest.json

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -29,7 +29,7 @@
                 "name": "swap_ack",
                 "ask": {
                     "en": "This application needs 500 Mo of RAM. The install script will automatically add swap on the system. Swap is not good if it's on an SD card life, though. Do you agree with adding swap (required) ?",
-                    "fr": "Cette application nécessite 500 Mo de RAM. Le script d'installation va automatiquement ajouter du swap sur le système. Cependant, l'utilisation de swap risque de diminuer sa durée de vie. Êtes-vous d'accord avec l'ajout de swap (requis) ?"
+                    "fr": "Cette application necessite 500 Mo de RAM. Le script d'installation va automatiquement ajouter du swap sur le systeme. Cependant, l'utilisation de swap risque de diminuer sa duree de vie. Etes-vous d'accord avec l'ajout de swap (requis) ?"
                 },
                 "choices": [ "Yes", "No" ],
                 "default": "No"
@@ -58,7 +58,7 @@
                 "type": "user",
                 "ask": {
                     "en": "Choose an admin user",
-                    "fr": "Choisissez l’administrateur"
+                    "fr": "Choisissez l'administrateur"
                 },
                 "example": "johndoe"
             },


### PR DESCRIPTION
The install was crashing, getting a traceback from python: UnicodeDecodeError: 'ascii' codec can't decode byte 0xc3 in position 971: ordinal not in range(128). Removed the unicode characters from the manifest.json and it works great now. 